### PR TITLE
Add enchantments topping

### DIFF
--- a/burger/toppings/enchantments.py
+++ b/burger/toppings/enchantments.py
@@ -1,0 +1,33 @@
+from .topping import Topping
+
+class EnchantmentsTopping(Topping):
+    """Provides a list of all enchantments"""
+
+    PROVIDES = [
+        "enchantments"
+    ]
+    DEPENDS = ["identify.enchantments"]
+
+    @staticmethod
+    def act(aggregate, classloader, verbose=False):
+        enchantments = []
+        cf = classloader[aggregate["classes"]["enchantments"]]
+        # Method is either <clinit> or a void with no parameters, check both
+        # until we find one that loads constants
+        for meth in cf.methods.find(args = '', returns = 'V'):
+            ops = tuple(meth.code.disassemble())
+            if(next(x for x in ops if 'ldc' in x.name), False):
+                break
+        for idx, op in enumerate(ops):
+            if 'ldc' in op.name:
+                str_val = op.operands[0].string.value
+
+                # Enum identifiers in older version of MC are all uppercase,
+                # these are distinct from the enchantment strings we're
+                # collecting here.
+                if str_val.isupper():
+                    continue
+
+                enchantments.append(str_val)
+
+        aggregate['enchantments'] = enchantments

--- a/burger/toppings/identify.py
+++ b/burger/toppings/identify.py
@@ -52,7 +52,8 @@ MATCHES = (
     ),
     (['has invalidly named property'], 'blockstatecontainer'),
     ((['HORIZONTAL'], True), 'enumfacing.plane'),
-    ((['bubble'], True), 'particletypes')
+    ((['bubble'], True), 'particletypes'),
+    ((['fire_protection'], True), 'enchantments')
 )
 
 # Enforce a lower priority on some matches, since some classes may match both
@@ -70,7 +71,11 @@ MAYBE_MATCHES = (
 
 # Similarly, in 1.13, "bubble" is ambiguous between the particle class and
 # particle list, but the particletypes topping works with the first result in that case.
-IGNORE_DUPLICATES = [ "biome.register", "particletypes" ]
+
+# The "fire_protection" string is duplicated in the same way, but in that case
+# the enchantments topping will work with either class so we don't care which
+# is returned.
+IGNORE_DUPLICATES = [ "biome.register", "particletypes", "enchantments" ]
 
 def check_match(value, match_list):
     exact = False
@@ -264,6 +269,7 @@ class IdentifyTopping(Topping):
         "identify.blockstatecontainer",
         "identify.blockstate",
         "identify.chatcomponent",
+        "identify.enchantments",
         "identify.entity.list",
         "identify.entity.trackerentry",
         "identify.enumfacing.plane",


### PR DESCRIPTION
This is to address https://github.com/PrismarineJS/minecraft-data/issues/325

It uses the exact same approach as the particletypes topping. There's more useful data to be extracted from enchantments (Slot restrictions, rarity, protection status), but this is enough to address the minecraft-data issue. The string ambiguity is irrelevant for the time being since both detected classes load all of the string constants.

Tested on every version >= 1.8.8