### PR TITLE
Fix particletypes topping for 1.17

### DIFF
--- a/burger/toppings/particletypes.py
+++ b/burger/toppings/particletypes.py
@@ -1,11 +1,10 @@
 from .topping import Topping
 
+
 class ParticleTypesTopping(Topping):
     """Provides a list of all particle types"""
 
-    PROVIDES = [
-        "particletypes"
-    ]
+    PROVIDES = ["particletypes"]
     DEPENDS = ["identify.particletypes"]
 
     @staticmethod
@@ -14,10 +13,11 @@ class ParticleTypesTopping(Topping):
         cf = classloader[aggregate["classes"]["particletypes"]]
         # Method is either <clinit> or a void with no parameters, check both
         # until we find one that loads constants
-        for meth in cf.methods.find(args = '', returns = 'V'):
+        for meth in cf.methods.find(args='', returns='V'):
             ops = tuple(meth.code.disassemble())
-            if(next(x for x in ops if 'ldc' in x.name), False):
+            if next(filter(lambda op: 'ldc' in op.name, ops), False):
                 break
+
         for idx, op in enumerate(ops):
             if 'ldc' in op.name:
                 str_val = op.operands[0].string.value


### PR DESCRIPTION
Because of a typo this topping was working mostly by accident and broke in 1.17, this PR fixes that