### PR TITLE
Fix items and tags toppings in 1.17

### DIFF
--- a/burger/toppings/items.py
+++ b/burger/toppings/items.py
@@ -116,6 +116,8 @@ class ItemsTopping(Topping):
                     if isinstance(const, String) and const.string.value == "Unable to have damage AND stack.":
                         max_stack_method = method
                         break
+            if max_stack_method:
+                break
         if not max_stack_method:
             raise Exception("Couldn't find max stack size setter in " + builder_class)
 
@@ -166,9 +168,10 @@ class ItemsTopping(Topping):
                         current_item = {}
 
                         text_id = None
-                        idx = 0
-                        for arg in desc.args:
+                        for idx, arg in enumerate(desc.args):
                             if arg.name == blockclass:
+                                if isinstance(args[idx], list):
+                                    continue
                                 block = args[idx]
                                 text_id = block["text_id"]
                                 if "name" in block:
@@ -182,7 +185,6 @@ class ItemsTopping(Topping):
                                 text_id = current_item["text_id"]
                             elif arg.name == "java/lang/String":
                                 text_id = args[idx]
-                            idx += 1
 
                         if current_item == {} and not text_id:
                             if verbose:

--- a/burger/toppings/tags.py
+++ b/burger/toppings/tags.py
@@ -22,7 +22,8 @@ class TagsTopping(Topping):
             if not path.startswith(prefix) or not path.endswith(suffix):
                 continue
             key = path[len(prefix):-len(suffix)]
-            type, name = key.split("/", 2)
+            idx = key.find("/")
+            type, name = key[:idx], key[idx + 1:]
             with classloader.open(path) as fin:
                 data = json.load(fin)
             data["type"] = type


### PR DESCRIPTION
Blocks sometimes have derivative blocks in their args list.
Ex. The third argument for this walked method for Cauldron is the blocks "water_cauldron", "lava_cauldron", "powder_cauldron". 

This argument can be safely ignored for the purpose of building the item list.

Tags can have more than `/` in their key. The first `/` is the only one the tags topping needs to care about