### PR TITLE
Add super field to blocks

### DIFF
--- a/burger/toppings/blocks.py
+++ b/burger/toppings/blocks.py
@@ -153,7 +153,17 @@ class BlocksTopping(Topping):
 
             def on_new(self, ins, const):
                 class_name = const.name.value
-                return {"class": class_name}
+
+                super_classes = []
+                this_super_class = classloader[class_name].super_.name.value
+                while this_super_class != superclass:
+                    super_classes.append(this_super_class)
+                    try:
+                        this_super_class = classloader[this_super_class].super_.name.value
+                    except FileNotFoundError:
+                        break
+
+                return {"class": class_name, "super": super_classes}
 
             def on_invoke(self, ins, const, obj, args):
                 method_name = const.name_and_type.name.value
@@ -337,7 +347,17 @@ class BlocksTopping(Topping):
 
             def on_new(self, ins, const):
                 class_name = const.name.value
-                return {"class": class_name}
+
+                super_classes = []
+                this_super_class = classloader[class_name].super_.name.value
+                while this_super_class != superclass:
+                    super_classes.append(this_super_class)
+                    try:
+                        this_super_class = classloader[this_super_class].super_.name.value
+                    except FileNotFoundError:
+                        break
+
+                return {"class": class_name, "super": super_classes}
 
             def on_invoke(self, ins, const, obj, args):
                 method_name = const.name_and_type.name.value
@@ -444,8 +464,19 @@ class BlocksTopping(Topping):
                 # The beginning of a new block definition
                 const = ins.operands[0]
                 class_name = const.name.value
+                
+                super_classes = []
+                this_super_class = classloader[class_name].super_.name.value
+                while this_super_class != superclass:
+                    super_classes.append(this_super_class)
+                    try:
+                        this_super_class = classloader[this_super_class].super_.name.value
+                    except FileNotFoundError:
+                        break
+                
                 current_block = {
                     "class": class_name,
+                    "super": super_classes,
                     "calls": {}
                 }
 
@@ -630,6 +661,7 @@ class BlocksTopping(Topping):
                 final["text_id"] = blk["text_id"]
 
             final["class"] = blk["class"]
+            final["super"] = blk["super"]
 
             if name_setter in blk["calls"]:
                 final["name"] = blk["calls"][name_setter][0]

--- a/burger/toppings/blocks.py
+++ b/burger/toppings/blocks.py
@@ -48,6 +48,18 @@ class BlocksTopping(Topping):
     ]
 
     @staticmethod
+    def list_super_classes(class_name, superclass, classloader):
+        super_classes = []
+        this_super_class = class_name
+        while this_super_class != superclass:
+            try:
+                this_super_class = classloader[this_super_class].super_.name.value
+            except FileNotFoundError:
+                break
+            super_classes.append(this_super_class)
+        return super_classes
+
+    @staticmethod
     def act(aggregate, classloader, verbose=False):
         data_version = aggregate["version"]["data"] if "data" in aggregate["version"] else -1
         if data_version >= 1901: # 18w43a
@@ -154,14 +166,7 @@ class BlocksTopping(Topping):
             def on_new(self, ins, const):
                 class_name = const.name.value
 
-                super_classes = []
-                this_super_class = classloader[class_name].super_.name.value
-                while this_super_class != superclass:
-                    super_classes.append(this_super_class)
-                    try:
-                        this_super_class = classloader[this_super_class].super_.name.value
-                    except FileNotFoundError:
-                        break
+                super_classes = BlocksTopping.list_super_classes(class_name, superclass, classloader)
 
                 return {"class": class_name, "super": super_classes}
 
@@ -348,14 +353,7 @@ class BlocksTopping(Topping):
             def on_new(self, ins, const):
                 class_name = const.name.value
 
-                super_classes = []
-                this_super_class = classloader[class_name].super_.name.value
-                while this_super_class != superclass:
-                    super_classes.append(this_super_class)
-                    try:
-                        this_super_class = classloader[this_super_class].super_.name.value
-                    except FileNotFoundError:
-                        break
+                super_classes = BlocksTopping.list_super_classes(class_name, superclass, classloader)
 
                 return {"class": class_name, "super": super_classes}
 
@@ -465,14 +463,7 @@ class BlocksTopping(Topping):
                 const = ins.operands[0]
                 class_name = const.name.value
                 
-                super_classes = []
-                this_super_class = classloader[class_name].super_.name.value
-                while this_super_class != superclass:
-                    super_classes.append(this_super_class)
-                    try:
-                        this_super_class = classloader[this_super_class].super_.name.value
-                    except FileNotFoundError:
-                        break
+                super_classes = BlocksTopping.list_super_classes(class_name, superclass, classloader)
                 
                 current_block = {
                     "class": class_name,


### PR DESCRIPTION
Adds a new `super` field to blocks that lists the (obfuscated) names of the super classes for the block class. I added this so I can iterate over the class + super classes to find the field_name in the mappings, but it could probably be used for other stuff.

I tested this for 1.8, 1.12, 1.13, and 1.19 and it works for all of them.
