### PR TITLE
Fix ServerboundHelloPacket instructions

### DIFF
--- a/burger/toppings/packetinstructions.py
+++ b/burger/toppings/packetinstructions.py
@@ -392,7 +392,7 @@ class PacketInstructionsTopping(Topping):
                     stack.insert(
                         -3 if stack[-3].category == 2 else -4, stack[-1]
                     )
-            elif mnemonic in ("return", "lreturn", "freturn", "dreturn", "areturn"):
+            elif mnemonic in ("return", "ireturn", "lreturn", "freturn", "dreturn", "areturn"):
                 # Don't attempt to lookup the instruction in the handler
                 pass
 

--- a/burger/toppings/packetinstructions.py
+++ b/burger/toppings/packetinstructions.py
@@ -392,7 +392,7 @@ class PacketInstructionsTopping(Topping):
                     stack.insert(
                         -3 if stack[-3].category == 2 else -4, stack[-1]
                     )
-            elif mnemonic == "return":
+            elif mnemonic in ("return", "lreturn", "freturn", "dreturn", "areturn"):
                 # Don't attempt to lookup the instruction in the handler
                 pass
 


### PR DESCRIPTION
Burger complains about "areturn" and "putfield" being unknown instructions when generating ServerboundHelloPacket (aka LOGIN_SERVERBOUND_00). This fixes it by ignoring the "areturn" instruction (and the other returns just in case).

