### PR TITLE
fix protocol versions 6 through 12

### DIFF
--- a/burger/toppings/packetinstructions.py
+++ b/burger/toppings/packetinstructions.py
@@ -643,7 +643,7 @@ class PacketInstructionsTopping(Topping):
             return [Operation(instruction.pos, "write", type="itemstack", field=arg)]
         elif arg_type == classes["chatcomponent"]:
             return [Operation(instruction.pos, "write", type="chatcomponent", field=arg)]
-        elif arg_type == classes["identifier"]:
+        elif arg_type == classes.get("identifier"):
             return [Operation(instruction.pos, "write", type="identifier", field=arg)]
         elif "position" not in classes or arg_type == classes["position"]:
             if "position" not in classes:


### PR DESCRIPTION
identifier class wasn't present in these versions, yet position was. it tried to get
the identifier class and failed.
using `.get(` doesn't give a hard error and fixes these old versions.