### PR TITLE
fix protocol version 15..25

### DIFF
--- a/burger/toppings/identify.py
+++ b/burger/toppings/identify.py
@@ -161,7 +161,8 @@ def identify(classloader, path, verbose):
             else:
                 for c2 in class_file.constants.find(type_=String):
                     if c2 == 'Tesselating block in world':
-                        break
+                        # Rendering code, which we don't care about
+                        return
                 else:
                     return 'block.list', class_file.this.name.value
 

--- a/burger/toppings/identify.py
+++ b/burger/toppings/identify.py
@@ -160,7 +160,7 @@ def identify(classloader, path, verbose):
                     return 'block.register', class_file.this.name.value
             else:
                 for c2 in class_file.constants.find(type_=String):
-                    if c2 == 'missingno':
+                    if c2 == 'Tesselating block in world':
                         break
                 else:
                     return 'block.list', class_file.this.name.value

--- a/burger/toppings/identify.py
+++ b/burger/toppings/identify.py
@@ -159,7 +159,11 @@ def identify(classloader, path, verbose):
                     # not in the list, only in registry
                     return 'block.register', class_file.this.name.value
             else:
-                return 'block.list', class_file.this.name.value
+                for c2 in class_file.constants.find(type_=String):
+                    if c2 == 'missingno':
+                        break
+                else:
+                    return 'block.list', class_file.this.name.value
 
         if value == 'diamond_pickaxe':
             # Similarly, diamond_pickaxe is only an item.  This exists in 3 classes, though:


### PR DESCRIPTION
there were three files with `piston_head` in them, the one which we don't care about which appeared as a duplicate `block.list` can be eliminated by checking if the file contains the string ~~`missingno`~~ `Tesselating block in world`