### PR TITLE
Fix blocks topping in 22w42a

### DIFF
--- a/burger/toppings/identify.py
+++ b/burger/toppings/identify.py
@@ -213,7 +213,6 @@ def identify(classloader, path, verbose):
             if len(list(fields)) == 2:
                 return 'identifier', class_file.this.name.value
 
-
         if value == 'PooledMutableBlockPosition modified after it was released.':
             # Keep on going up the class hierarchy until we find a logger,
             # which is declared in the main BlockPos class

--- a/burger/toppings/identify.py
+++ b/burger/toppings/identify.py
@@ -212,6 +212,21 @@ def identify(classloader, path, verbose):
             if len(list(fields)) == 2:
                 return 'identifier', class_file.this.name.value
 
+            # if it couldn't find Identifier with that, then it might be because we're in 22w42a/1.19.3+
+
+            def is_private_final(m):
+                return m.access_flags.acc_private and m.access_flags.acc_final
+
+            find_args = {
+                "type_": "Ljava/lang/String;",
+                "f": is_private_final
+            }
+            fields = class_file.fields.find(**find_args)
+
+            if len(list(fields)) == 2:
+                return 'identifier', class_file.this.name.value
+
+
         if value == 'PooledMutableBlockPosition modified after it was released.':
             # Keep on going up the class hierarchy until we find a logger,
             # which is declared in the main BlockPos class

--- a/burger/toppings/identify.py
+++ b/burger/toppings/identify.py
@@ -200,26 +200,13 @@ def identify(classloader, path, verbose):
             class_file = classloader[path]
 
             # Look for two protected final strings
-            def is_protected_final(m):
-                return m.access_flags.acc_protected and m.access_flags.acc_final
+            def is_protected_final_or_private_final(m):
+                # 22w42a/1.19.3+ makes it private instead of protected
+                return (m.access_flags.acc_protected or m.access_flags.acc_private) and m.access_flags.acc_final
 
             find_args = {
                 "type_": "Ljava/lang/String;",
-                "f": is_protected_final
-            }
-            fields = class_file.fields.find(**find_args)
-
-            if len(list(fields)) == 2:
-                return 'identifier', class_file.this.name.value
-
-            # if it couldn't find Identifier with that, then it might be because we're in 22w42a/1.19.3+
-
-            def is_private_final(m):
-                return m.access_flags.acc_private and m.access_flags.acc_final
-
-            find_args = {
-                "type_": "Ljava/lang/String;",
-                "f": is_private_final
+                "f": is_protected_final_or_private_final
             }
             fields = class_file.fields.find(**find_args)
 

--- a/burger/toppings/identify.py
+++ b/burger/toppings/identify.py
@@ -199,7 +199,7 @@ def identify(classloader, path, verbose):
         if value == 'minecraft':
             class_file = classloader[path]
 
-            # Look for two protected final strings
+            # Look for two protected/private final strings
             def is_protected_final_or_private_final(m):
                 # 22w42a/1.19.3+ makes it private instead of protected
                 return (m.access_flags.acc_protected or m.access_flags.acc_private) and m.access_flags.acc_final


### PR DESCRIPTION
They changed `protected final String` to `private final String` in the identifier class in the new 1.19.3 snapshot, which made it so Burger couldn't find it. (and the blocks topping depends on the identifier class being known)