### PR TITLE
Fix instructions for some packets

### DIFF
--- a/burger/toppings/packetinstructions.py
+++ b/burger/toppings/packetinstructions.py
@@ -673,7 +673,7 @@ class PacketInstructionsTopping(Topping):
     def _handle_2_arg_buffer_call(classloader, classes, instruction, verbose,
                                   cls, name, desc, instance, args):
         if desc.args[0].name == "java/lang/String" and desc.args[1].name == "int":
-            max_length = args[1]
+            max_length = int(args[1].value, 0) # the 0 makes it handle the 0x prefix if it's there
             return [Operation(instruction.pos, "write", type="string", field=args[0], length=max_length)]
         elif desc.args[0].name == "com/mojang/serialization/Codec":
             codec = args[0]
@@ -771,7 +771,7 @@ class PacketInstructionsTopping(Topping):
         elif desc.args[0].name == classes.get("idmap"):
             return [Operation(instruction.pos, "write", type="varint", field="%s.getId(%s)" % (args[0], args[1]))]
         elif desc.args[0].name == "java/util/BitSet":
-            max_length = args[1]
+            max_length = int(args[1].value, 0) # the 0 makes it handle the 0x prefix if it's there
             return [Operation(instruction.pos, "write", type="bitset", field=args[0], length=max_length)]
         elif desc.args[0].name == "java/util/EnumSet":
             # bitset with a max length of the enum's constant count


### PR DESCRIPTION
This PR fixes instruction extraction erroring for several packets. I'm not sure how many of these were broken specifically by 22w42a but I fixed them all regardless.

Changes:
- Add the BitSet type (which required adding a `length` field to it, and I also added that length field to String because I might as well)
- Add the EnumSet type
- Add the Either type (I don't really like the .isLeft()/.left()/.right() thing but I don't know what the best way to do it would be)
- Handle the `putfield` instruction (Advancement.Builder's writer set a field when writing a packet for some reason)

(Note: I haven't looked into the new snapshot that released today yet so I'm hoping they didn't add more weird types)
