### PR TITLE
Handle Quaternionf and Vector3f in entity metadata

### DIFF
--- a/burger/toppings/entitymetadata.py
+++ b/burger/toppings/entitymetadata.py
@@ -168,6 +168,12 @@ class EntityMetadataTopping(Topping):
                     elif const.name_and_type.name == "<init>":
                         if const.class_.name == self.textcomponentstring:
                             obj["text"] = args[0]
+                        if const.class_.name == 'org/joml/Vector3f':
+                            if len(args) > 0:
+                                obj["x"], obj["y"], obj["z"] = args
+                        if const.class_.name == 'org/joml/Quaternionf':
+                            if len(args) > 0:
+                                obj["x"], obj["y"], obj["z"], obj["w"] = args
 
                         return
                     elif const.class_.name == datamanager_class:
@@ -221,6 +227,11 @@ class EntityMetadataTopping(Topping):
                 def on_new(self, ins, const):
                     if self.waiting_for_putfield:
                         return
+
+                    if const.name.value == "org/joml/Quaternionf":
+                        return {"x": 0, "y": 0, "z": 0, "w": 1}
+                    elif const.name.value == "org/joml/Vector3f":
+                        return {"x": 0, "y": 0, "z": 0}
 
                     if self.textcomponentstring == None:
                         # Check if this is TextComponentString

--- a/burger/toppings/entitymetadata.py
+++ b/burger/toppings/entitymetadata.py
@@ -168,10 +168,10 @@ class EntityMetadataTopping(Topping):
                     elif const.name_and_type.name == "<init>":
                         if const.class_.name == self.textcomponentstring:
                             obj["text"] = args[0]
-                        if const.class_.name == 'org/joml/Vector3f':
+                        elif const.class_.name == 'org/joml/Vector3f':
                             if len(args) > 0:
                                 obj["x"], obj["y"], obj["z"] = args
-                        if const.class_.name == 'org/joml/Quaternionf':
+                        elif const.class_.name == 'org/joml/Quaternionf':
                             if len(args) > 0:
                                 obj["x"], obj["y"], obj["z"], obj["w"] = args
 
@@ -233,7 +233,7 @@ class EntityMetadataTopping(Topping):
                     elif const.name.value == "org/joml/Vector3f":
                         return {"x": 0, "y": 0, "z": 0}
 
-                    if self.textcomponentstring == None:
+                    elif self.textcomponentstring == None:
                         # Check if this is TextComponentString
                         temp_cf = classloader[const.name.value]
                         for str in temp_cf.constants.find(type_=String):

--- a/burger/toppings/entitymetadata.py
+++ b/burger/toppings/entitymetadata.py
@@ -509,6 +509,8 @@ class EntityMetadataTopping(Topping):
             name = inner_type[len("java/lang/"):]
             if name == "Integer":
                 name = "VarInt"
+        elif inner_type.startswith("org/joml/"):
+            name = inner_type[len("org/joml/"):]
         elif inner_type == "java/util/UUID":
             name = "UUID"
         elif inner_type == "java/util/OptionalInt":


### PR DESCRIPTION
The new snapshot added a new "display" entity which contains metadata fields that are of type org.joml.Vector3f and org.joml.Quaternionf. Right now burger errors and fails to generate entity metadata since it doesn't know how to handle those, this fixes that.

