### PR TITLE
Extra info for the version topping

### DIFF
--- a/burger/toppings/version.py
+++ b/burger/toppings/version.py
@@ -164,7 +164,7 @@ class VersionTopping(Topping):
                                 versions["name"] = str
                                 versions["id"] = versions["name"]
                                 return
-                            elif "Outdated server!" in str:
+                            elif "Outdated server! I'm still on " in str:
                                 if version is None:
                                     # 13w41a and 13w41b (protocol version 0)
                                     # don't explicitly set the variable
@@ -174,6 +174,19 @@ class VersionTopping(Topping):
                                     str[len("Outdated server! I'm still on "):]
                                 versions["id"] = versions["name"]
                                 return
+                            elif str == "Outdated server!":
+                                for class_name in classloader.classes:
+                                    for const in classloader.search_constant_pool(path=class_name, type_=String):
+                                        value = const.string.value
+                                        if "Starting integrated minecraft server version " in value:
+                                            versions["name"] = value[len("Starting integrated minecraft server version "):]
+                                            versions["id"] = versions["name"]
+                                            return
+                                        elif "Starting minecraft server version " in value:
+                                            versions["name"] = value[len("Starting minecraft server version "):]
+                                            versions["id"] = versions["name"]
+                                            return
+
         elif versions["distribution"] == "client" and "nethandler.client" in aggregate["classes"]:
             # If we know this is the client, and there's no nethandler.server, this is a version prior to the codebase merge (12w17a or prior)
             # We need to look for the protocol name and version elsewhere


### PR DESCRIPTION
This PR covers some of what was discussed in #45. It includes the following changes to the version topping:

- A new `distribution` property to specify whether the analyzed .jar file is a client or server distribution. This is mostly useful in helping discerning versions prior to the client/server codebase merge (12w17a and prior), but still correctly idenfities versions after that.
- A new `netty_rewrite` property to specify whether the version is post netty rewrite (13w41a and later). This is to help avoid clashings due to the protocol version number reset.
- Fix for the missing protocol/name/id in client versions prior to the codebase merge (12w17a and prior).