### PR TITLE
Changes/fixes for the identify topping

### DIFF
--- a/burger/toppings/identify.py
+++ b/burger/toppings/identify.py
@@ -35,6 +35,7 @@ MATCHES = (
     (['Fetching addPacket for removed entity', 'Fetching packet for removed entity'], 'entity.trackerentry'),
     (['#%04d/%d%s', 'attribute.modifier.equals.'], 'itemstack'),
     (['disconnect.lost'], 'nethandler.client'),
+    ([' just tried to change non-editable sign'], 'nethandler.server'),
     (['Outdated server!', 'multiplayer.disconnect.outdated_client'],
         'nethandler.handshake'),
     (['Corrupt NBT tag'], 'nbtcompound'),

--- a/burger/toppings/identify.py
+++ b/burger/toppings/identify.py
@@ -36,8 +36,6 @@ MATCHES = (
     (['#%04d/%d%s', 'attribute.modifier.equals.'], 'itemstack'),
     (['disconnect.lost'], 'nethandler.client'),
     ([' just tried to change non-editable sign'], 'nethandler.server'),
-    (['Outdated server!', 'multiplayer.disconnect.outdated_client'],
-        'nethandler.handshake'),
     (['Corrupt NBT tag'], 'nbtcompound'),
     ([' is already assigned to protocol '], 'packet.connectionstate'),
     (
@@ -281,6 +279,13 @@ def identify(classloader, path, verbose):
             for c2 in class_file.constants.find(type_=String):
                 if c2 == "Someone's been tampering with the universe!":
                     return "enumfacing.plane", class_file.this.name.value
+                
+        if 'Outdated server!' in value or 'multiplayer.disconnect.outdated_client' in value:
+            # 1.7.7 and 1.7.8 both have a similar message on the client nethandler, which we are not interested in
+            if "to be 1.7." in value:
+                continue
+
+            return "nethandler.handshake", classloader[path].this.name.value
 
     # May (will usually) be None
     return possible_match

--- a/burger/toppings/identify.py
+++ b/burger/toppings/identify.py
@@ -129,7 +129,8 @@ def identify(classloader, path, verbose):
                             # The chatcomponent type is its first parameter.
                             return 'chatcomponent', method.args[0][2]
                     elif ins.mnemonic == "invokedynamic":
-                        if 'as a Component' in string_from_invokedymanic(ins, class_file):
+                        const = string_from_invokedymanic(ins, class_file)
+                        if const is not None and 'as a Component' in const:
                             return 'chatcomponent', method.args[0][2]
             else:
                 if verbose:

--- a/burger/toppings/identify.py
+++ b/burger/toppings/identify.py
@@ -316,6 +316,7 @@ class IdentifyTopping(Topping):
         "identify.nbtcompound",
         "identify.nethandler.client",
         "identify.nethandler.handshake",
+        "identify.nethandler.server",
         "identify.packet.connectionstate",
         "identify.packet.packetbuffer",
         "identify.particle",

--- a/burger/toppings/identify.py
+++ b/burger/toppings/identify.py
@@ -36,7 +36,7 @@ MATCHES = (
     (['#%04d/%d%s', 'attribute.modifier.equals.'], 'itemstack'),
     (['disconnect.lost'], 'nethandler.client'),
     (['Outdated server!', 'multiplayer.disconnect.outdated_client'],
-        'nethandler.server'),
+        'nethandler.handshake'),
     (['Corrupt NBT tag'], 'nbtcompound'),
     ([' is already assigned to protocol '], 'packet.connectionstate'),
     (
@@ -308,7 +308,7 @@ class IdentifyTopping(Topping):
         "identify.metadata",
         "identify.nbtcompound",
         "identify.nethandler.client",
-        "identify.nethandler.server",
+        "identify.nethandler.handshake",
         "identify.packet.connectionstate",
         "identify.packet.packetbuffer",
         "identify.particle",

--- a/burger/toppings/version.py
+++ b/burger/toppings/version.py
@@ -44,7 +44,7 @@ class VersionTopping(Topping):
     ]
 
     DEPENDS = [
-        "identify.nethandler.server",
+        "identify.nethandler.handshake",
         "identify.anvilchunkloader"
     ]
 
@@ -142,8 +142,8 @@ class VersionTopping(Topping):
     @staticmethod
     def get_protocol_version(aggregate, classloader, verbose):
         versions = aggregate["version"]
-        if "nethandler.server" in aggregate["classes"]:
-            nethandler = aggregate["classes"]["nethandler.server"]
+        if "nethandler.handshake" in aggregate["classes"]:
+            nethandler = aggregate["classes"]["nethandler.handshake"]
             cf = classloader[nethandler]
             version = None
             looking_for_version_name = False
@@ -188,7 +188,7 @@ class VersionTopping(Topping):
                                             return
 
         elif versions["distribution"] == "client" and "nethandler.client" in aggregate["classes"]:
-            # If we know this is the client, and there's no nethandler.server, this is a version prior to the codebase merge (12w17a or prior)
+            # If we know this is the client, and there's no nethandler.handshake, this is a version prior to the codebase merge (12w17a or prior)
             # We need to look for the protocol name and version elsewhere
 
             # We can get the name from the startup class

--- a/burger/util.py
+++ b/burger/util.py
@@ -429,10 +429,12 @@ def try_eval_lambda(ins, args, cf):
 
 def string_from_invokedymanic(ins, cf):
     """
-    Gets the recipe string for a string concatenation implemented via invokedynamic.
+    Gets the recipe string, if this is a string concatenation implemented via invokedynamic.
     """
     info = InvokeDynamicInfo.create(ins, cf)
-    assert isinstance(info, StringConcatInvokeDynamicInfo)
+    if not isinstance(info, StringConcatInvokeDynamicInfo):
+        return
+    
     return info.recipe
 
 class WalkerCallback(ABC):


### PR DESCRIPTION
This PR covers some of what was discussed in #45. It includes the following changes to the identify topping:

- Change of `nethandler.server` to `nethandler.handshake` for consistency.
- Addition of the actual `nethandler.server`.
- Fixes on the identification of `nethandler.handshake` for versions 1.7.7 and 1.7.8, and `chatcomponent` for 18w43a through 18w43c, which are currently broken and cause the whole topping to fail.