### PR TITLE
Fixes for 1.20.3

### DIFF
--- a/burger/toppings/blocks.py
+++ b/burger/toppings/blocks.py
@@ -202,7 +202,7 @@ class BlocksTopping(Topping):
                             # string so it can be handled the same.
                             and (
                                 desc.args[0].name == "java/lang/String"
-                                or desc.args[0].name == aggregate["classes"]["resourcekey"]
+                                or desc.args[0].name == aggregate["classes"].get("resourcekey")
                             )
                             and desc.args[1].name == superclass
                         ):

--- a/burger/toppings/blocks.py
+++ b/burger/toppings/blocks.py
@@ -114,6 +114,21 @@ class BlocksTopping(Topping):
         else:
             language = None
 
+        # 23w40a+ (1.20.3) has a references class that defines the IDs for some blocks
+        references_class = aggregate["classes"].get("block.references")
+        references_class_fields_to_block_ids = {}
+        if references_class:
+            # process the references class
+            references_cf = classloader[references_class]
+            for method in references_cf.methods.find(name='<clinit>'):
+                block_id = None
+                for ins in method.code.disassemble():
+                    if ins.mnemonic == 'ldc':
+                        block_id = ins.operands[0].string.value
+                    if ins.mnemonic == 'putstatic':
+                        field = ins.operands[0].name_and_type.name.value
+                        references_class_fields_to_block_ids[field] = block_id
+
         # Figure out what the builder class is
         ctor = cf.methods.find_one(name="<init>")
         builder_class = ctor.args[0].name
@@ -179,7 +194,18 @@ class BlocksTopping(Topping):
 
                 if ins.mnemonic == "invokestatic":
                     if const.class_.name.value == listclass:
-                        if len(desc.args) == 2 and desc.args[0].name == "java/lang/String" and desc.args[1].name == superclass:
+                        if (
+                            len(desc.args) == 2
+                            # In 23w40a+ (1.20.3) the first argument can also be a reference to a
+                            # ResourceKey<Block> in the block references class. We have a check in
+                            # on_get_field that makes the argument get converted to a block ID
+                            # string so it can be handled the same.
+                            and (
+                                desc.args[0].name == "java/lang/String"
+                                or desc.args[0].name == aggregate["classes"]["resourcekey"]
+                            )
+                            and desc.args[1].name == superclass
+                        ):
                             # Call to the static register method.
                             text_id = args[0]
                             current_block = args[1]
@@ -256,6 +282,13 @@ class BlocksTopping(Topping):
                 if const.class_.name.value == superclass:
                     # Probably getting the static AIR resource location
                     return "air"
+                elif const.class_.name.value == references_class:
+                    # get the block key from the references.Block class
+                    if const.name_and_type.name.value in references_class_fields_to_block_ids:
+                        return references_class_fields_to_block_ids[const.name_and_type.name.value]
+                    else:
+                        print("Unknown field", const.name_and_type.name.value, "in references class", references_class)
+                        return None
                 elif const.class_.name.value == listclass:
                     if const.name_and_type.name.value in block_fields:
                         return block[block_fields[const.name_and_type.name.value]]

--- a/burger/toppings/blocks.py
+++ b/burger/toppings/blocks.py
@@ -287,7 +287,8 @@ class BlocksTopping(Topping):
                     if const.name_and_type.name.value in references_class_fields_to_block_ids:
                         return references_class_fields_to_block_ids[const.name_and_type.name.value]
                     else:
-                        print("Unknown field", const.name_and_type.name.value, "in references class", references_class)
+                        if verbose:
+                            print("Unknown field", const.name_and_type.name.value, "in references class", references_class)
                         return None
                 elif const.class_.name.value == listclass:
                     if const.name_and_type.name.value in block_fields:

--- a/burger/toppings/identify.py
+++ b/burger/toppings/identify.py
@@ -114,8 +114,10 @@ def identify(classloader, path, verbose):
 
     class_file = classloader[path]
 
-    string_constants = classloader.search_constant_pool(path=path, type_=String)
-    for c in string_constants:
+    has_string_constants = False
+
+    for c in classloader.search_constant_pool(path=path, type_=String):
+        has_string_constants = True
         value = c.string.value
         for match_list, match_name in MATCHES:
             if check_match(value, match_list):
@@ -317,7 +319,7 @@ def identify(classloader, path, verbose):
             return "nethandler.handshake", class_file.this.name.value
 
     # chatcomponent doesn't have any constant strings after 23w46a (1.20.3), so identify it by field and method signatures
-    if string_constants == []:
+    if not has_string_constants:
         # the class should have one `private static final Gson GSON`
         def is_gson_field(f):
             return f.access_flags.acc_private and f.access_flags.acc_static \

--- a/burger/toppings/identify.py
+++ b/burger/toppings/identify.py
@@ -142,7 +142,7 @@ def identify(classloader, path, verbose):
                         len(m.args) == 1 and m.returns.name == "java/lang/String"
 
                 methods = list(class_file.methods.find(f=is_serialize_method))
-                if len(methods) == 1:
+                if len(methods) > 0:
                     return "chatcomponent", methods[0].args[0].name
 
             if value == 'ambient.cave':
@@ -262,6 +262,7 @@ def identify(classloader, path, verbose):
                 # Also, this is the _only_ string constant available to us.
                 # Finally, note that PooledMutableBlockPos was introduced in 1.9.
                 # This technique will not work in 1.8.
+                cf = classloader[path]
                 logger_type = "Lorg/apache/logging/log4j/Logger;"
                 while not cf.fields.find_one(type_=logger_type):
                     if cf.super_.name == "java/lang/Object":
@@ -320,7 +321,7 @@ def identify(classloader, path, verbose):
                 for c2 in class_file.constants.find(type_=String):
                     if c2 == "Someone's been tampering with the universe!":
                         return "enumfacing.plane", class_file.this.name.value
-                    
+
             if 'Outdated server!' in value or 'multiplayer.disconnect.outdated_client' in value:
                 # 1.7.7 and 1.7.8 both have a similar message on the client nethandler, which we are not interested in
                 if "to be 1.7." in value:

--- a/burger/toppings/identify.py
+++ b/burger/toppings/identify.py
@@ -112,227 +112,243 @@ def identify(classloader, path, verbose):
     """
     possible_match = None
 
-    class_file = classloader[path]
+    for c in classloader.search_constant_pool(path=path):
+        if isinstance(c, String):
+            value = c.string.value
+            for match_list, match_name in MATCHES:
+                if check_match(value, match_list):
+                    class_file = classloader[path]
+                    return match_name, class_file.this.name.value
 
-    has_string_constants = False
+            for match_list, match_name in MAYBE_MATCHES:
+                if check_match(value, match_list):
+                    class_file = classloader[path]
+                    possible_match = (match_name, class_file.this.name.value)
+                    # Continue searching through the other constants in the class
 
-    for c in classloader.search_constant_pool(path=path, type_=String):
-        has_string_constants = True
-        value = c.string.value
-        for match_list, match_name in MATCHES:
-            if check_match(value, match_list):
-                return match_name, class_file.this.name.value
+            if "as a Component" in value or "Couldn't get field 'lineStart' for JsonReader" in value:
+                # This class is the JSON serializer/deserializer for the chat component.
+                # (The "as a Component" String exists starting in 13w36a (1.7.2), but
+                # was removed in 23w40a. The "Couldn't get field 'lineStart' for JsonReader"
+                # string exists since at least 1.20.2 and was removed in 1.20.3. We have another
+                # check in the `if isinstance(c, ConstantClass):` to handle 1.20.3+.)
 
-        for match_list, match_name in MAYBE_MATCHES:
-            if check_match(value, match_list):
-                possible_match = (match_name, class_file.this.name.value)
-                # Continue searching through the other constants in the class
+                # Look for a method that returns a String, and assume that it takes a component as its
+                # sole parameter.
+                class_file = classloader[path]
 
-        if "as a Component" in value or "Couldn't get field 'lineStart' for JsonReader" in value:
-            # This class is the JSON serializer/deserializer for the chat component.
-            # (The "as a Component" String exists starting in 13w36a (1.7.2), but
-            # was removed in 23w40a. The "Couldn't get field 'lineStart' for JsonReader"
-            # string exists since at least 1.20.2 and was removed in 1.20.3. We have another check
-            # after the string constants loop to handle 1.20.3+.)
-
-            # Look for a method that returns a String, and assume that it takes a component as its
-            # sole parameter.
-
-            def is_serialize_method(m):
-                return m.access_flags.acc_public and m.access_flags.acc_static and \
-                       len(m.args) == 1 and m.returns.name == "java/lang/String"
-
-            methods = list(class_file.methods.find(f=is_serialize_method))
-            if len(methods) == 1:
-                return "chatcomponent", methods[0].args[0].name
-
-        if value == 'ambient.cave':
-            # This is found in both the sounds list class and sounds event class.
-            # However, the sounds list class also has a constant specific to it.
-            # Note that this method will not work in 1.8, but the list class doesn't exist then either.
-
-            for c2 in class_file.constants.find(type_=String):
-                if c2 == 'Accessed Sounds before Bootstrap!':
-                    return 'sounds.list', class_file.this.name.value
-            else:
-                return 'sounds.event', class_file.this.name.value
-
-        if value == 'piston_head':
-            # piston_head is a technical block, which is important as that means it has no item form.
-            # This constant is found in both the block list class and the class containing block registrations.
-
-            for c2 in class_file.constants.find(type_=String):
-                if c2 == 'doTileDrops':
-                    # not in the list, only in registry
-                    return 'block.register', class_file.this.name.value
-            for c2 in class_file.constants.find(type_=String):
-                if c2 == 'Tesselating block in world':
-                    # Rendering code, which we don't care about
-                    return
-            for c2 in class_file.constants.find(type_=ConstantClass):
-                if c2.name == 'com/mojang/serialization/MapCodec':
-                    # In 23w40a (1.20.3), a BlockTypes class was added that handles the codec for blocks,
-                    # which duplicates all of the block identifier strings. As a pretty awful
-                    # heuristic, ignore classes that reference the codec. Note that the codec
-                    # system isn't obfuscated.
-                    return
-            return 'block.list', class_file.this.name.value
-
-        if value == 'diamond_pickaxe':
-            # Similarly, diamond_pickaxe is only an item.  This exists in 3 classes, though:
-            # - The actual item registration code
-            # - The item list class
-            # - The item renderer class (until 1.13), which we don't care about
-
-            for c2 in class_file.constants.find(type_=String):
-                if c2 == 'textures/misc/enchanted_item_glint.png':
-                    # Item renderer, which we don't care about
-                    return
-
-                if c2 == 'CB3F55D3-645C-4F38-A497-9C13A33DB5CF':
-                    # Item registry always contains this uuid for
-                    # "BASE_ATTACK_DAMAGE_UUID"
-                    return 'item.register', class_file.this.name.value
-            else:
-                return 'item.list', class_file.this.name.value
-
-        if value == 'attached_pumpkin_stem':
-            # 23w40a (1.20.3) adds a references/Blocks class with entries that look like:
-            # public static final ResourceKey<Block> ATTACHED_PUMPKIN_STEM = createKey("attached_pumpkin_stem");
-
-            for c2 in class_file.constants.find(type_=String):
-                # make sure it's not the normal block list class
-                if c2 == 'air':
-                    return
-
-            return 'block.references', class_file.this.name.value
-
-        if value == 'pumpkin_seeds':
-            # the items list is similar, but with items instead of blocks:
-            # public static final ResourceKey<Item> PUMPKIN_SEEDS = createKey("pumpkin_seeds");
-
-            for c2 in class_file.constants.find(type_=String):
-                # again, this is to make sure it's not the normal item list class
-
-                # note that this might break in the future if the "diamond_pickaxe" string is moved
-                # to the references class
-                if c2 == 'diamond_pickaxe':
-                    return
-
-            return 'item.references', class_file.this.name.value
-
-        if value in ('Ice Plains', 'mutated_ice_flats', 'ice_spikes'):
-            # Finally, biomes.  There's several different names that were used for this one biome
-            # Only classes are the list class and the one with registration.  Note that the list didn't exist in 1.8.
-
-            for c2 in class_file.constants.find(type_=String):
-                if c2 == 'Accessed Biomes before Bootstrap!':
-                    return 'biome.list', class_file.this.name.value
-            else:
-                return 'biome.register', class_file.this.name.value
-
-        if value == 'minecraft':
-            # Look for two protected/private final strings
-            def is_protected_final_or_private_final(m):
-                # 22w42a/1.19.3+ makes it private instead of protected
-                return (m.access_flags.acc_protected or m.access_flags.acc_private) and m.access_flags.acc_final
-
-            find_args = {
-                "type_": "Ljava/lang/String;",
-                "f": is_protected_final_or_private_final
-            }
-            fields = class_file.fields.find(**find_args)
-
-            if len(list(fields)) == 2:
-                return 'identifier', class_file.this.name.value
-
-        if value == 'PooledMutableBlockPosition modified after it was released.':
-            # Keep on going up the class hierarchy until we find a logger,
-            # which is declared in the main BlockPos class
-            # We can't hardcode a specific number of classes to go up, as
-            # in some versions PooledMutableBlockPos extends BlockPos directly,
-            # but in others have PooledMutableBlockPos extend MutableBlockPos.
-            # Also, this is the _only_ string constant available to us.
-            # Finally, note that PooledMutableBlockPos was introduced in 1.9.
-            # This technique will not work in 1.8.
-            logger_type = "Lorg/apache/logging/log4j/Logger;"
-            while not cf.fields.find_one(type_=logger_type):
-                if cf.super_.name == "java/lang/Object":
-                    cf = None
-                    break
-                cf = classloader[cf.super_.name.value]
-            if cf:
-                return 'position', cf.this.name.value
-
-        if value == 'Getting block state':
-            # This message is found in Chunk, in the method getBlockState.
-            # We could also theoretically identify BlockPos from this method,
-            # but currently identify only allows marking one class at a time.
-
-            for method in class_file.methods:
-                for ins in method.code.disassemble():
-                    if ins.mnemonic in ("ldc", "ldc_w"):
-                        if ins.operands[0] == 'Getting block state':
-                            return 'blockstate', method.returns.name
-            else:
-                if verbose:
-                    print("Found chunk as %s, but didn't find the method that returns blockstate" % path)
-
-        if value == 'particle.notFound':
-            # This is in ParticleArgument, which is used for commands and
-            # implements brigadier's ArgumentType<IParticleData>.
-
-            if len(class_file.interfaces) == 1 and class_file.interfaces[0].name == "com/mojang/brigadier/arguments/ArgumentType":
-                sig = class_file.attributes.find_one(name="Signature").signature.value
-                inner_type = sig[sig.index("<") + 1 : sig.rindex(">")][1:-1]
-                return "particle", inner_type
-            elif verbose:
-                print("Found ParticleArgument as %s, but it didn't implement the expected interface" % path)
-
-        if value == 'HORIZONTAL':
-            # In 22w43a, there is a second enum with HORIZONTAL and VERTICAL as members (used in UI
-            # code), not just enumfacing.plane. They can be differentiated by the constructors.
-            # This constructor was added in 1.13.
-            # Prior to 1.13, the string "Someone's been tampering with the universe!" indicates
-            # enumfacing.plane. After, it instead indicates the x/y/z axis. So, if we don't find
-            # a matching constructor, check for that string constant instead. That string constant
-            # was removed entirely in 1.18 (it existed in 1.17). I'm not sure of which specific
-            # snapshots this was changed in.
-
-            def is_enumfacing_plane_constructor(m):
-                # We're looking for EnumFacing$Plane(EnumFacing[], EnumFacing$Axis[]).
-                # Java synthetically adds parameters for enum name and ordinal, so that constructor
-                # has 4 parameters, with the last 2 being arrays.
-                return len(m.args) == 4 and m.args[2].dimensions == 1 and m.args[3].dimensions==1
-
-            if len(list(class_file.methods.find(name="<init>", f=is_enumfacing_plane_constructor))) != 0:
-                return "enumfacing.plane", class_file.this.name.value
-            for c2 in class_file.constants.find(type_=String):
-                if c2 == "Someone's been tampering with the universe!":
-                    return "enumfacing.plane", class_file.this.name.value
-                
-        if 'Outdated server!' in value or 'multiplayer.disconnect.outdated_client' in value:
-            # 1.7.7 and 1.7.8 both have a similar message on the client nethandler, which we are not interested in
-            if "to be 1.7." in value:
-                continue
-
-            return "nethandler.handshake", class_file.this.name.value
-
-    # chatcomponent doesn't have any constant strings after 23w46a (1.20.3), so identify it by field and method signatures
-    if not has_string_constants:
-        # the class should have one `private static final Gson GSON`
-        def is_gson_field(f):
-            return f.access_flags.acc_private and f.access_flags.acc_static \
-                and f.access_flags.acc_final and f.descriptor == 'Lcom/google/gson/Gson;'
-        gson_fields = list(class_file.fields.find(f=is_gson_field))
-        if gson_fields != []:
-            # and also a method that looks like `public static String toJson(Component)`
-            def is_serialize_method(m):
-                return m.access_flags.acc_public and m.access_flags.acc_static and \
+                def is_serialize_method(m):
+                    return m.access_flags.acc_public and m.access_flags.acc_static and \
                         len(m.args) == 1 and m.returns.name == "java/lang/String"
-            serialize_methods = list(class_file.methods.find(f=is_serialize_method))
-            if len(serialize_methods) == 1:
-                return "chatcomponent", serialize_methods[0].args[0].name
+
+                methods = list(class_file.methods.find(f=is_serialize_method))
+                if len(methods) == 1:
+                    return "chatcomponent", methods[0].args[0].name
+
+            if value == 'ambient.cave':
+                # This is found in both the sounds list class and sounds event class.
+                # However, the sounds list class also has a constant specific to it.
+                # Note that this method will not work in 1.8, but the list class doesn't exist then either.
+                class_file = classloader[path]
+
+                for c2 in class_file.constants.find(type_=String):
+                    if c2 == 'Accessed Sounds before Bootstrap!':
+                        return 'sounds.list', class_file.this.name.value
+                else:
+                    return 'sounds.event', class_file.this.name.value
+
+            if value == 'piston_head':
+                # piston_head is a technical block, which is important as that means it has no item form.
+                # This constant is found in both the block list class and the class containing block registrations.
+                class_file = classloader[path]
+
+                for c2 in class_file.constants.find(type_=String):
+                    if c2 == 'doTileDrops':
+                        # not in the list, only in registry
+                        return 'block.register', class_file.this.name.value
+                for c2 in class_file.constants.find(type_=String):
+                    if c2 == 'Tesselating block in world':
+                        # Rendering code, which we don't care about
+                        return
+                for c2 in class_file.constants.find(type_=ConstantClass):
+                    if c2.name == 'com/mojang/serialization/MapCodec':
+                        # In 23w40a (1.20.3), a BlockTypes class was added that handles the codec for blocks,
+                        # which duplicates all of the block identifier strings. As a pretty awful
+                        # heuristic, ignore classes that reference the codec. Note that the codec
+                        # system isn't obfuscated.
+                        return
+                return 'block.list', class_file.this.name.value
+
+            if value == 'diamond_pickaxe':
+                # Similarly, diamond_pickaxe is only an item.  This exists in 3 classes, though:
+                # - The actual item registration code
+                # - The item list class
+                # - The item renderer class (until 1.13), which we don't care about
+                class_file = classloader[path]
+
+                for c2 in class_file.constants.find(type_=String):
+                    if c2 == 'textures/misc/enchanted_item_glint.png':
+                        # Item renderer, which we don't care about
+                        return
+
+                    if c2 == 'CB3F55D3-645C-4F38-A497-9C13A33DB5CF':
+                        # Item registry always contains this uuid for
+                        # "BASE_ATTACK_DAMAGE_UUID"
+                        return 'item.register', class_file.this.name.value
+                else:
+                    return 'item.list', class_file.this.name.value
+
+            if value == 'attached_pumpkin_stem':
+                # 23w40a (1.20.3) adds a references/Blocks class with entries that look like:
+                # public static final ResourceKey<Block> ATTACHED_PUMPKIN_STEM = createKey("attached_pumpkin_stem");
+                class_file = classloader[path]
+
+                for c2 in class_file.constants.find(type_=String):
+                    # make sure it's not the normal block list class
+                    if c2 == 'air':
+                        return
+
+                return 'block.references', class_file.this.name.value
+
+            if value == 'pumpkin_seeds':
+                # the items list is similar, but with items instead of blocks:
+                # public static final ResourceKey<Item> PUMPKIN_SEEDS = createKey("pumpkin_seeds");
+                class_file = classloader[path]
+
+                for c2 in class_file.constants.find(type_=String):
+                    # again, this is to make sure it's not the normal item list class
+
+                    # note that this might break in the future if the "diamond_pickaxe" string is moved
+                    # to the references class
+                    if c2 == 'diamond_pickaxe':
+                        return
+
+                return 'item.references', class_file.this.name.value
+
+            if value in ('Ice Plains', 'mutated_ice_flats', 'ice_spikes'):
+                # Finally, biomes.  There's several different names that were used for this one biome
+                # Only classes are the list class and the one with registration.  Note that the list didn't exist in 1.8.
+                class_file = classloader[path]
+
+                for c2 in class_file.constants.find(type_=String):
+                    if c2 == 'Accessed Biomes before Bootstrap!':
+                        return 'biome.list', class_file.this.name.value
+                else:
+                    return 'biome.register', class_file.this.name.value
+
+            if value == 'minecraft':
+                class_file = classloader[path]
+
+                # Look for two protected/private final strings
+                def is_protected_final_or_private_final(m):
+                    # 22w42a/1.19.3+ makes it private instead of protected
+                    return (m.access_flags.acc_protected or m.access_flags.acc_private) and m.access_flags.acc_final
+
+                find_args = {
+                    "type_": "Ljava/lang/String;",
+                    "f": is_protected_final_or_private_final
+                }
+                fields = class_file.fields.find(**find_args)
+
+                if len(list(fields)) == 2:
+                    return 'identifier', class_file.this.name.value
+
+            if value == 'PooledMutableBlockPosition modified after it was released.':
+                # Keep on going up the class hierarchy until we find a logger,
+                # which is declared in the main BlockPos class
+                # We can't hardcode a specific number of classes to go up, as
+                # in some versions PooledMutableBlockPos extends BlockPos directly,
+                # but in others have PooledMutableBlockPos extend MutableBlockPos.
+                # Also, this is the _only_ string constant available to us.
+                # Finally, note that PooledMutableBlockPos was introduced in 1.9.
+                # This technique will not work in 1.8.
+                logger_type = "Lorg/apache/logging/log4j/Logger;"
+                while not cf.fields.find_one(type_=logger_type):
+                    if cf.super_.name == "java/lang/Object":
+                        cf = None
+                        break
+                    cf = classloader[cf.super_.name.value]
+                if cf:
+                    return 'position', cf.this.name.value
+
+            if value == 'Getting block state':
+                # This message is found in Chunk, in the method getBlockState.
+                # We could also theoretically identify BlockPos from this method,
+                # but currently identify only allows marking one class at a time.
+                class_file = classloader[path]
+
+                for method in class_file.methods:
+                    for ins in method.code.disassemble():
+                        if ins.mnemonic in ("ldc", "ldc_w"):
+                            if ins.operands[0] == 'Getting block state':
+                                return 'blockstate', method.returns.name
+                else:
+                    if verbose:
+                        print("Found chunk as %s, but didn't find the method that returns blockstate" % path)
+
+            if value == 'particle.notFound':
+                # This is in ParticleArgument, which is used for commands and
+                # implements brigadier's ArgumentType<IParticleData>.
+                class_file = classloader[path]
+
+                if len(class_file.interfaces) == 1 and class_file.interfaces[0].name == "com/mojang/brigadier/arguments/ArgumentType":
+                    sig = class_file.attributes.find_one(name="Signature").signature.value
+                    inner_type = sig[sig.index("<") + 1 : sig.rindex(">")][1:-1]
+                    return "particle", inner_type
+                elif verbose:
+                    print("Found ParticleArgument as %s, but it didn't implement the expected interface" % path)
+
+            if value == 'HORIZONTAL':
+                # In 22w43a, there is a second enum with HORIZONTAL and VERTICAL as members (used in UI
+                # code), not just enumfacing.plane. They can be differentiated by the constructors.
+                # This constructor was added in 1.13.
+                # Prior to 1.13, the string "Someone's been tampering with the universe!" indicates
+                # enumfacing.plane. After, it instead indicates the x/y/z axis. So, if we don't find
+                # a matching constructor, check for that string constant instead. That string constant
+                # was removed entirely in 1.18 (it existed in 1.17). I'm not sure of which specific
+                # snapshots this was changed in.
+                class_file = classloader[path]
+
+                def is_enumfacing_plane_constructor(m):
+                    # We're looking for EnumFacing$Plane(EnumFacing[], EnumFacing$Axis[]).
+                    # Java synthetically adds parameters for enum name and ordinal, so that constructor
+                    # has 4 parameters, with the last 2 being arrays.
+                    return len(m.args) == 4 and m.args[2].dimensions == 1 and m.args[3].dimensions==1
+
+                if len(list(class_file.methods.find(name="<init>", f=is_enumfacing_plane_constructor))) != 0:
+                    return "enumfacing.plane", class_file.this.name.value
+                for c2 in class_file.constants.find(type_=String):
+                    if c2 == "Someone's been tampering with the universe!":
+                        return "enumfacing.plane", class_file.this.name.value
+                    
+            if 'Outdated server!' in value or 'multiplayer.disconnect.outdated_client' in value:
+                # 1.7.7 and 1.7.8 both have a similar message on the client nethandler, which we are not interested in
+                if "to be 1.7." in value:
+                    continue
+
+                class_file = classloader[path]
+
+                return "nethandler.handshake", class_file.this.name.value
+        if isinstance(c, ConstantClass):
+            if c.name == 'com/google/gson/Gson':
+                class_file = classloader[path]
+                # the class should have one `private static final Gson GSON`
+                def is_gson_field(f):
+                    return f.access_flags.acc_private and f.access_flags.acc_static \
+                        and f.access_flags.acc_final and f.descriptor == 'Lcom/google/gson/Gson;'
+                gson_fields = list(class_file.fields.find(f=is_gson_field))
+                if gson_fields != []:
+                    # and also a method that looks like `public static String toJson(Component)`
+                    def is_serialize_method(m):
+                        return m.access_flags.acc_public and m.access_flags.acc_static and \
+                                len(m.args) == 1 and m.returns.name == "java/lang/String"
+                    serialize_methods = list(class_file.methods.find(f=is_serialize_method))
+                    if len(serialize_methods) == 1:
+                        # final check to avoid false positives, abort if it has any string constants
+                        for c2 in class_file.constants.find(type_=String):
+                            return
+                        return "chatcomponent", serialize_methods[0].args[0].name
+                break
 
     # May (will usually) be None
     return possible_match

--- a/burger/toppings/identify.py
+++ b/burger/toppings/identify.py
@@ -141,7 +141,8 @@ def identify(classloader, path, verbose):
                        len(m.args) == 1 and m.returns.name == "java/lang/String"
 
             methods = list(class_file.methods.find(f=is_serialize_method))
-            return "chatcomponent", methods[0].args[0].name
+            if len(methods) == 1:
+                return "chatcomponent", methods[0].args[0].name
 
         if value == 'ambient.cave':
             # This is found in both the sounds list class and sounds event class.

--- a/burger/toppings/identify.py
+++ b/burger/toppings/identify.py
@@ -329,7 +329,6 @@ def identify(classloader, path, verbose):
                         len(m.args) == 1 and m.returns.name == "java/lang/String"
             serialize_methods = list(class_file.methods.find(f=is_serialize_method))
             if len(serialize_methods) == 1:
-                print('found chatcomponent', class_file.this.name.value, serialize_methods)
                 return "chatcomponent", serialize_methods[0].args[0].name
 
     # May (will usually) be None

--- a/burger/toppings/items.py
+++ b/burger/toppings/items.py
@@ -102,6 +102,21 @@ class ItemsTopping(Topping):
         else:
             language = None
 
+        # 23w40a+ (1.20.3) has a references class that defines the IDs for some items
+        references_class = aggregate["classes"].get("item.references")
+        references_class_fields_to_item_ids = {}
+        if references_class:
+            # process the references class
+            references_cf = classloader[references_class]
+            for method in references_cf.methods.find(name='<clinit>'):
+                item_id = None
+                for ins in method.code.disassemble():
+                    if ins.mnemonic == 'ldc':
+                        item_id = ins.operands[0].string.value
+                    if ins.mnemonic == 'putstatic':
+                        field = ins.operands[0].name_and_type.name.value
+                        references_class_fields_to_item_ids[field] = item_id
+
         # Figure out what the builder class is
         ctor = cf.methods.find_one(name="<init>")
         builder_class = ctor.args[0].name
@@ -185,6 +200,8 @@ class ItemsTopping(Topping):
                                 text_id = current_item["text_id"]
                             elif arg.name == "java/lang/String":
                                 text_id = args[idx]
+                            elif arg.name == aggregate["classes"]["resourcekey"]:
+                                text_id = args[idx]
 
                         if current_item == {} and not text_id:
                             if verbose:
@@ -259,6 +276,14 @@ class ItemsTopping(Topping):
                         return {}
                     else:
                         return aggregate["blocks"]["block"][block_name]
+                elif const.class_.name.value == references_class:
+                    # get the block key from the references.Item class
+                    if const.name_and_type.name.value in references_class_fields_to_item_ids:
+                        return references_class_fields_to_item_ids[const.name_and_type.name.value]
+                    else:
+                        print("Unknown field", const.name_and_type.name.value, "in references class", references_class)
+                        return None
+
                 elif const.class_.name.value == listclass:
                     return item_list[item_fields[const.name_and_type.name.value]]
                 else:

--- a/burger/toppings/items.py
+++ b/burger/toppings/items.py
@@ -281,7 +281,8 @@ class ItemsTopping(Topping):
                     if const.name_and_type.name.value in references_class_fields_to_item_ids:
                         return references_class_fields_to_item_ids[const.name_and_type.name.value]
                     else:
-                        print("Unknown field", const.name_and_type.name.value, "in references class", references_class)
+                        if verbose:
+                            print("Unknown field", const.name_and_type.name.value, "in references class", references_class)
                         return None
 
                 elif const.class_.name.value == listclass:

--- a/burger/toppings/items.py
+++ b/burger/toppings/items.py
@@ -200,7 +200,7 @@ class ItemsTopping(Topping):
                                 text_id = current_item["text_id"]
                             elif arg.name == "java/lang/String":
                                 text_id = args[idx]
-                            elif arg.name == aggregate["classes"]["resourcekey"]:
+                            elif arg.name == aggregate["classes"].get("resourcekey"):
                                 text_id = args[idx]
 
                         if current_item == {} and not text_id:


### PR DESCRIPTION
This PR has two fixes:
- chatcomponent (aka Component.Serializer) doesn't have any strings since 23w46a, so I changed it to be identified by the field and method signatures, and checking that it doesn't have any constant strings.
- Some block/item ids were changed to be defined in references.Blocks and references.Items classes, so I added identifiers for those classes and made it extract the strings from the disassembly.

I tested with 1.14.4, 23w40a, and 1.20.3-pre2.
